### PR TITLE
WIP: Add method Casts.unchecked

### DIFF
--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -38,6 +38,7 @@ package net.imglib2.type;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.LongAccess;
 import net.imglib2.img.basictypeaccess.array.LongArray;
+import net.imglib2.util.Util;
 
 /**
  * A {@link Type} with arbitrary bit depth up to maximum 64 bits.
@@ -167,5 +168,11 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 				}
 			}
 		}
+	}
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 }

--- a/src/main/java/net/imglib2/type/AbstractBit64Type.java
+++ b/src/main/java/net/imglib2/type/AbstractBit64Type.java
@@ -169,10 +169,4 @@ public abstract class AbstractBit64Type< T extends AbstractBit64Type< T > > exte
 			}
 		}
 	}
-
-	@Override
-	public boolean equals( Object obj )
-	{
-		return Util.valueEqualsObject( this, obj );
-	}
 }

--- a/src/main/java/net/imglib2/type/AbstractNativeType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeType.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.type;
 
+import net.imglib2.util.Util;
+
 /**
  * TODO
  * 
@@ -82,4 +84,10 @@ public abstract class AbstractNativeType< T extends AbstractNativeType< T >> imp
 
 	@Override
 	public abstract String toString();
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
 }

--- a/src/main/java/net/imglib2/type/AbstractNativeType.java
+++ b/src/main/java/net/imglib2/type/AbstractNativeType.java
@@ -84,10 +84,4 @@ public abstract class AbstractNativeType< T extends AbstractNativeType< T >> imp
 
 	@Override
 	public abstract String toString();
-
-	@Override
-	public boolean equals( Object obj )
-	{
-		return Util.valueEqualsObject( this, obj );
-	}
 }

--- a/src/main/java/net/imglib2/type/label/BasePairBitType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairBitType.java
@@ -52,7 +52,49 @@ public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implem
 	// hom many bits a BasePairBitType contains
 	private static final int NBITS = 3;
 
-	public static enum Base { gap, N, A, T, G, C, U; }
+	public enum Base
+	{
+		gap( ' ' ),
+		N( 'N' ),
+		A( 'A' ),
+		T( 'T' ),
+		G( 'G' ),
+		C( 'C' ),
+		U( 'U' );
+
+		private final char c;
+
+		Base( final char c )
+		{
+			this.c = c;
+		}
+
+		public char getChar()
+		{
+			return c;
+		}
+
+		public static Base fromChar( final char c )
+		{
+			switch ( c )
+			{
+			case 'A':
+				return A;
+			case 'T':
+				return T;
+			case 'G':
+				return G;
+			case 'C':
+				return C;
+			case 'U':
+				return U;
+			case ' ':
+				return gap;
+			default:
+				return N;
+			}
+		}
+	}
 
 	// this is the constructor if you want it to read from an array
 	public BasePairBitType( final NativeImg< ?, ? extends LongAccess > bitStorage )
@@ -119,25 +161,7 @@ public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implem
 	@Override
 	public byte baseToValue()
 	{
-		final Base base = get();
-
-		switch ( base )
-		{
-		case N:
-			return 1;
-		case A:
-			return 2;
-		case T:
-			return 3;
-		case G:
-			return 4;
-		case C:
-			return 5;
-		case U:
-			return 6;
-		default:
-			return 0;
-		}
+		return ( byte ) get().ordinal();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/BasePairBitType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairBitType.java
@@ -92,29 +92,13 @@ public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implem
 	@Override
 	public Base get()
 	{
-		return Base.values()[ (int)getBits() ];
+		return Base.values()[ ( int ) getBits() ];
 	}
 
 	@Override
 	public int compareTo( final BasePairBitType c )
 	{
-		final Base input = get();
-		final Base compare = c.get();
-
-		if ( input == compare )
-		{
-			return 0;
-		}
-		switch ( input )
-		{
-			case gap: return -1;
-			case N: return compare == Base.gap ? 1 : -1;
-			case A: return compare == Base.gap || compare == Base.N ? 1 : -1;
-			case T: return compare == Base.G || compare == Base.C || compare == Base.U ? -1 : 1;
-			case G: return compare == Base.C || compare == Base.U ? -1 : 1;
-			case C: return compare == Base.U ? -1 : 1;
-			default: return 1;
-		}
+		return get().compareTo( c.get() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/label/BasePairBitType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairBitType.java
@@ -49,18 +49,21 @@ import net.imglib2.type.NativeTypeFactory;
  */
 public class BasePairBitType extends AbstractBit64Type< BasePairBitType > implements BasePairType< BasePairBitType >
 {
+	// hom many bits a BasePairBitType contains
+	private static final int NBITS = 3;
+
 	public static enum Base { gap, N, A, T, G, C, U; }
 
 	// this is the constructor if you want it to read from an array
 	public BasePairBitType( final NativeImg< ?, ? extends LongAccess > bitStorage )
 	{
-		super( bitStorage, 3 );
+		super( bitStorage, NBITS );
 	}
 
 	// this is the constructor if you want it to be a variable
 	public BasePairBitType( final Base value )
 	{
-		super( value.ordinal() );
+		super( value.ordinal(), NBITS );
 	}
 
 	// this is the constructor if you want it to be a variable

--- a/src/main/java/net/imglib2/type/label/BasePairCharType.java
+++ b/src/main/java/net/imglib2/type/label/BasePairCharType.java
@@ -124,54 +124,13 @@ public class BasePairCharType extends AbstractNativeType< BasePairCharType > imp
 	@Override
 	public void set( final Base base )
 	{
-		switch ( base )
-		{
-		case A:
-			setChar( 'A' );
-			return;
-		case T:
-			setChar( 'T' );
-			return;
-		case G:
-			setChar( 'G' );
-			return;
-		case C:
-			setChar( 'C' );
-			return;
-		case U:
-			setChar( 'U' );
-			return;
-		case gap:
-			setChar( ' ' );
-			return;
-		default:
-			setChar( 'N' );
-			return;
-		}
+		setChar( base.getChar() );
 	}
 
 	@Override
 	public Base get()
 	{
-		final char value = getChar();
-
-		switch ( value )
-		{
-		case 'A':
-			return Base.A;
-		case 'T':
-			return Base.T;
-		case 'G':
-			return Base.G;
-		case 'C':
-			return Base.C;
-		case 'U':
-			return Base.U;
-		case ' ':
-			return Base.gap;
-		default:
-			return Base.N;
-		}
+		return Base.fromChar( getChar() );
 	}
 
 	@Override
@@ -183,27 +142,7 @@ public class BasePairCharType extends AbstractNativeType< BasePairCharType > imp
 	@Override
 	public int compareTo( final BasePairCharType c )
 	{
-		final char input = getChar();
-		final char compare = c.getChar();
-
-		if ( input == compare ) { return 0; }
-		switch ( input )
-		{
-		case ' ':
-			return -1;
-		case 'N':
-			return compare == ' ' ? 1 : -1;
-		case 'A':
-			return compare == ' ' || compare == 'N' ? 1 : -1;
-		case 'T':
-			return compare == 'G' || compare == 'C' || compare == 'U' ? -1 : 1;
-		case 'G':
-			return compare == 'C' || compare == 'U' ? -1 : 1;
-		case 'C':
-			return compare == 'U' ? -1 : 1;
-		default:
-			return 1;
-		}
+		return get().compareTo( c.get() );
 	}
 
 	@Override
@@ -233,25 +172,7 @@ public class BasePairCharType extends AbstractNativeType< BasePairCharType > imp
 	@Override
 	public byte baseToValue()
 	{
-		final char base = getChar();
-
-		switch ( base )
-		{
-		case 'N':
-			return 1;
-		case 'A':
-			return 2;
-		case 'T':
-			return 3;
-		case 'G':
-			return 4;
-		case 'C':
-			return 5;
-		case 'U':
-			return 6;
-		default:
-			return 0;
-		}
+		return ( byte ) get().ordinal();
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -292,15 +292,7 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	@Override
 	public int compareTo( final BitType c )
 	{
-		final boolean b1 = get();
-		final boolean b2 = c.get();
-
-		if ( b1 && !b2 )
-			return 1;
-		else if ( !b1 && b2 )
-			return -1;
-		else
-			return 0;
+		return Boolean.compare( get(), c.get() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -376,4 +376,10 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	{
 		return get() == t.get();
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return Boolean.hashCode( get() );
+	}
 }

--- a/src/main/java/net/imglib2/type/logic/BitType.java
+++ b/src/main/java/net/imglib2/type/logic/BitType.java
@@ -45,6 +45,7 @@ import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.AbstractIntegerType;
 import net.imglib2.util.Fraction;
+import net.imglib2.util.Util;
 
 /**
  * TODO
@@ -290,12 +291,6 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	}
 
 	@Override
-	public int compareTo( final BitType c )
-	{
-		return Boolean.compare( get(), c.get() );
-	}
-
-	@Override
 	public BitType createVariable()
 	{
 		return new BitType();
@@ -364,9 +359,21 @@ public class BitType extends AbstractIntegerType< BitType > implements BooleanTy
 	}
 
 	@Override
+	public int compareTo( final BitType other )
+	{
+		return Boolean.compare( get(), other.get() );
+	}
+
+	@Override
 	public boolean valueEquals( final BitType t )
 	{
 		return get() == t.get();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/BoolType.java
+++ b/src/main/java/net/imglib2/type/logic/BoolType.java
@@ -83,10 +83,7 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	@Override
 	public int compareTo( final BoolType o )
 	{
-		if ( value )
-			return o.value ? 0 : 1;
-		else
-			return o.value ? -1 : 0;
+		return Boolean.compare( value, o.value );
 	}
 
 	@Override
@@ -193,7 +190,7 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	{
 		set( b.compareTo(BigInteger.ZERO) > 0 );
 	}
-	
+
 	@Override
 	public boolean valueEquals( BoolType t )
 	{

--- a/src/main/java/net/imglib2/type/logic/BoolType.java
+++ b/src/main/java/net/imglib2/type/logic/BoolType.java
@@ -199,4 +199,10 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	{
 		return get() == t.get();
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return Boolean.hashCode( get() );
+	}
 }

--- a/src/main/java/net/imglib2/type/logic/BoolType.java
+++ b/src/main/java/net/imglib2/type/logic/BoolType.java
@@ -37,6 +37,7 @@ import java.math.BigInteger;
 
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.integer.AbstractIntegerType;
+import net.imglib2.util.Util;
 
 /**
  * A {@link BooleanType} wrapping a single primitive {@code boolean} variable.
@@ -78,12 +79,6 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	public void set( final BoolType c )
 	{
 		value = c.get();
-	}
-
-	@Override
-	public int compareTo( final BoolType o )
-	{
-		return Boolean.compare( value, o.value );
 	}
 
 	@Override
@@ -192,9 +187,21 @@ public class BoolType extends AbstractIntegerType< BoolType > implements Boolean
 	}
 
 	@Override
+	public int compareTo( final BoolType other )
+	{
+		return Boolean.compare( get(), other.get() );
+	}
+
+	@Override
 	public boolean valueEquals( BoolType t )
 	{
 		return get() == t.get();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/logic/NativeBoolType.java
+++ b/src/main/java/net/imglib2/type/logic/NativeBoolType.java
@@ -277,14 +277,7 @@ public class NativeBoolType extends AbstractIntegerType< NativeBoolType > implem
 	@Override
 	public int compareTo( final NativeBoolType c )
 	{
-		final boolean b1 = get();
-		final boolean b2 = c.get();
-
-		if ( b1 && !b2 )
-			return 1;
-		if ( !b1 && b2 )
-			return -1;
-		return 0;
+		return Boolean.compare( get(), c.get() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/ARGBType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBType.java
@@ -250,4 +250,10 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 	{
 		return get() == t.get();
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return Integer.hashCode( get() );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/ARGBType.java
+++ b/src/main/java/net/imglib2/type/numeric/ARGBType.java
@@ -252,6 +252,12 @@ public class ARGBType extends AbstractNativeType< ARGBType > implements NumericT
 	}
 
 	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
 	public int hashCode()
 	{
 		return Integer.hashCode( get() );

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -36,6 +36,8 @@ package net.imglib2.type.numeric;
 
 import net.imglib2.util.Util;
 
+import java.util.Objects;
+
 /**
  * 
  * @author Stephan Saalfeld
@@ -171,5 +173,16 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 	public boolean equals( Object obj )
 	{
 		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: this is the same as Objects.hashCode( getA(), getR(), getG(), getB() ) but faster, no boxing, no memory allocation
+		int result = 31 + Double.hashCode( getA() );
+		result = 31 * result + Double.hashCode( getR() );
+		result = 31 * result + Double.hashCode( getG() );
+		result = 31 * result + Double.hashCode( getB() );
+		return result;
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -166,4 +166,10 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 				( getG() == t.getG() ) &&
 				( getB() == t.getB() );
 	}
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -34,6 +34,7 @@
 
 package net.imglib2.type.numeric;
 
+import net.imglib2.util.Casts;
 import net.imglib2.util.Util;
 
 /**
@@ -170,11 +171,7 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if( ! getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings( "unchecked" )
-		T t = ( T ) obj;
-		return AbstractARGBDoubleType.this.valueEquals( t );
+		return getClass().isInstance( obj ) && AbstractARGBDoubleType.this.valueEquals( Casts.unchecked( obj ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/AbstractARGBDoubleType.java
@@ -36,8 +36,6 @@ package net.imglib2.type.numeric;
 
 import net.imglib2.util.Util;
 
-import java.util.Objects;
-
 /**
  * 
  * @author Stephan Saalfeld
@@ -170,9 +168,13 @@ abstract public class AbstractARGBDoubleType< T extends AbstractARGBDoubleType< 
 	}
 
 	@Override
-	public boolean equals( Object obj )
+	public boolean equals( final Object obj )
 	{
-		return Util.valueEqualsObject( this, obj );
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return AbstractARGBDoubleType.this.valueEquals( t );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
@@ -169,26 +169,6 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 	}
 
 	@Override
-	public boolean equals( final Object o )
-	{
-		if ( !getClass().isInstance(o) )
-			return false;
-		@SuppressWarnings("unchecked")
-		final T t = (T) o;
-		return getRealDouble() == t.getRealDouble() &&
-			getImaginaryDouble() == t .getImaginaryDouble();
-	}
-
-	@Override
-	public int hashCode()
-	{
-		// NB: Compute similar hash code to java.lang.Double#hashCode().
-		final long rBits = Double.doubleToLongBits(getRealDouble());
-		final long iBits = Double.doubleToLongBits(getImaginaryDouble());
-		return (int) (rBits ^ (rBits >>> 32) ^ iBits ^ (iBits >>> 32));
-	}
-
-	@Override
 	public String toString()
 	{
 		return "(" + getRealDouble() + ") + (" + getImaginaryDouble() + ")i";

--- a/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/AbstractComplexType.java
@@ -35,6 +35,7 @@
 package net.imglib2.type.numeric.complex;
 
 import net.imglib2.type.numeric.ComplexType;
+import net.imglib2.util.Util;
 
 /**
  * TODO
@@ -166,6 +167,31 @@ public abstract class AbstractComplexType< T extends AbstractComplexType< T >> i
 	{
 		setReal( r );
 		setImaginary( i );
+	}
+
+	@Override
+	public boolean valueEquals( T other )
+	{
+		return getRealDouble() == other.getRealDouble() &&
+				getImaginaryDouble() == other.getImaginaryDouble();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if ( !getClass().isInstance(obj) )
+			return false;
+		@SuppressWarnings("unchecked")
+		final T t = (T) obj;
+		return AbstractComplexType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		final int hash1 = Double.hashCode( getRealDouble() );
+		final int hash2 = Double.hashCode( getImaginaryDouble() );
+		return Util.combineHash( hash1, hash2 );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -242,4 +242,20 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 		return doubleToLongBits( getRealDouble() ) == doubleToLongBits( t.getRealDouble() ) &&
 				doubleToLongBits( getImaginaryDouble() ) == doubleToLongBits( t.getImaginaryDouble() );
 	}
+
+	@Override
+	public boolean equals( final Object o )
+	{
+		return ( o instanceof ComplexDoubleType )
+				&& valueEquals( ( ComplexDoubleType ) o );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: Compute similar hash code to java.lang.Double#hashCode().
+		final long rBits = doubleToLongBits( getRealDouble() );
+		final long iBits = doubleToLongBits( getImaginaryDouble() );
+		return ( int ) ( rBits ^ ( rBits >>> 32 ) ^ iBits ^ ( iBits >>> 32 ) );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -41,6 +41,8 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
 
+import static java.lang.Double.doubleToLongBits;
+
 /**
  * TODO
  *
@@ -237,7 +239,7 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	@Override
 	public boolean valueEquals( final ComplexDoubleType t )
 	{
-		return ( getRealDouble() == t.getRealDouble() ) &&
-				( getImaginaryDouble() == t.getImaginaryDouble() );
+		return doubleToLongBits( getRealDouble() ) == doubleToLongBits( t.getRealDouble() ) &&
+				doubleToLongBits( getImaginaryDouble() ) == doubleToLongBits( t.getImaginaryDouble() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexDoubleType.java
@@ -235,27 +235,4 @@ public class ComplexDoubleType extends AbstractComplexType< ComplexDoubleType > 
 	{
 		return i;
 	}
-
-	@Override
-	public boolean valueEquals( final ComplexDoubleType t )
-	{
-		return doubleToLongBits( getRealDouble() ) == doubleToLongBits( t.getRealDouble() ) &&
-				doubleToLongBits( getImaginaryDouble() ) == doubleToLongBits( t.getImaginaryDouble() );
-	}
-
-	@Override
-	public boolean equals( final Object o )
-	{
-		return ( o instanceof ComplexDoubleType )
-				&& valueEquals( ( ComplexDoubleType ) o );
-	}
-
-	@Override
-	public int hashCode()
-	{
-		// NB: Compute similar hash code to java.lang.Double#hashCode().
-		final long rBits = doubleToLongBits( getRealDouble() );
-		final long iBits = doubleToLongBits( getImaginaryDouble() );
-		return ( int ) ( rBits ^ ( rBits >>> 32 ) ^ iBits ^ ( iBits >>> 32 ) );
-	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
@@ -296,4 +296,20 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 		return ( floatToIntBits( getRealFloat() ) == floatToIntBits( t.getRealFloat() ) ) &&
 				( floatToIntBits( getImaginaryFloat() ) == floatToIntBits( t.getImaginaryFloat() ) );
 	}
+
+	@Override
+	public boolean equals( final Object o )
+	{
+		return ( o instanceof ComplexFloatType )
+				&& valueEquals( ( ComplexFloatType ) o );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		// NB: Compute similar hash code to java.lang.Float#hashCode().
+		final int rBits = floatToIntBits( getRealFloat() );
+		final int iBits = floatToIntBits( getImaginaryFloat() );
+		return rBits ^ iBits;
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
@@ -41,6 +41,8 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
 
+import static java.lang.Float.floatToIntBits;
+
 /**
  * TODO
  *
@@ -291,7 +293,7 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	@Override
 	public boolean valueEquals( final ComplexFloatType t )
 	{
-		return ( getRealFloat() == t.getRealFloat() ) &&
-				( getImaginaryFloat() == t.getImaginaryFloat() );
+		return ( floatToIntBits( getRealFloat() ) == floatToIntBits( t.getRealFloat() ) ) &&
+				( floatToIntBits( getImaginaryFloat() ) == floatToIntBits( t.getImaginaryFloat() ) );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/complex/ComplexFloatType.java
@@ -40,6 +40,7 @@ import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
+import net.imglib2.util.Util;
 
 import static java.lang.Float.floatToIntBits;
 
@@ -293,23 +294,21 @@ public class ComplexFloatType extends AbstractComplexType< ComplexFloatType > im
 	@Override
 	public boolean valueEquals( final ComplexFloatType t )
 	{
-		return ( floatToIntBits( getRealFloat() ) == floatToIntBits( t.getRealFloat() ) ) &&
-				( floatToIntBits( getImaginaryFloat() ) == floatToIntBits( t.getImaginaryFloat() ) );
+		return getRealFloat() == t.getRealFloat() &&
+				getImaginaryFloat() == t.getImaginaryFloat();
 	}
 
 	@Override
-	public boolean equals( final Object o )
+	public boolean equals( final Object obj )
 	{
-		return ( o instanceof ComplexFloatType )
-				&& valueEquals( ( ComplexFloatType ) o );
+		return Util.valueEqualsObject( this, obj );
 	}
 
 	@Override
 	public int hashCode()
 	{
-		// NB: Compute similar hash code to java.lang.Float#hashCode().
-		final int rBits = floatToIntBits( getRealFloat() );
-		final int iBits = floatToIntBits( getImaginaryFloat() );
-		return rBits ^ iBits;
+		final int hash1 = Float.hashCode( getRealFloat() );
+		final int hash2 = Float.hashCode( getImaginaryFloat() );
+		return Util.combineHash( hash1, hash2 );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerBitType.java
@@ -97,32 +97,23 @@ public abstract class AbstractIntegerBitType< T extends AbstractIntegerBitType< 
 	public void setOne() { setInteger( 1 ); }
 
 	@Override
-	public boolean equals( final Object o ) {
-		if ( !getClass().isInstance(o) )
+	public boolean equals( final Object obj ) {
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings("unchecked")
-		final T t = (T) o;
-		return compareTo(t) == 0;
+		final T t = (T) obj;
+		return AbstractIntegerBitType.this.valueEquals( t );
 	}
 
 	@Override
 	public int hashCode() {
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		final long value = get();
-		return (int) (value ^ (value >>> 32));
+		return Long.hashCode( get() );
 	}
 
 	@Override
-	public int compareTo( final T c )
+	public int compareTo( final T other )
 	{
-		final long a = getIntegerLong();
-		final long b = c.getIntegerLong();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
+		return Long.compare( getIntegerLong(), other.getIntegerLong() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
@@ -36,6 +36,7 @@ package net.imglib2.type.numeric.integer;
 
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.real.AbstractRealType;
+import net.imglib2.util.Casts;
 import net.imglib2.util.Util;
 
 /**
@@ -119,11 +120,7 @@ public abstract class AbstractIntegerType< T extends AbstractIntegerType< T > > 
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( !getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings("unchecked")
-		final T t = ( T ) obj;
-		return AbstractIntegerType.this.valueEquals( t );
+		return getClass().isInstance( obj ) &&AbstractIntegerType.this.valueEquals( Casts.unchecked( obj ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/AbstractIntegerType.java
@@ -99,29 +99,37 @@ public abstract class AbstractIntegerType< T extends AbstractIntegerType< T > > 
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		final long value = getIntegerLong();
-		return ( int ) ( value ^ ( value >>> 32 ) );
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final long a = getIntegerLong();
-		final long b = c.getIntegerLong();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public String toString()
 	{
-		return "" + getIntegerLong();
+		return Long.toString( getIntegerLong() );
 	}
+
+	@Override
+	public int compareTo( final T other )
+	{
+		return Long.compare( getIntegerLong(), other.getIntegerLong() );
+	}
+
+	@Override
+	public boolean valueEquals( T other )
+	{
+		return getIntegerLong() == getIntegerLong();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if ( !getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings("unchecked")
+		final T t = ( T ) obj;
+		return AbstractIntegerType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Long.hashCode( getIntegerLong() );
+	}
+
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericByteType.java
@@ -178,26 +178,6 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Byte#hashCode().
-		return getByte();
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final byte a = getByte();
-		final byte b = c.getByte();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public void set( final T c )
 	{
 		setByte( c.getByte() );
@@ -278,8 +258,31 @@ public abstract class GenericByteType< T extends GenericByteType< T > > extends 
 	}
 
 	@Override
+	public int compareTo( final T other )
+	{
+		// NB: Use Integer.compare because Byte.compare returns value different from -1, 0, 1.
+		return Integer.compare( getByte(), other.getByte() );
+	}
+
+	@Override
 	public boolean valueEquals( final T t )
 	{
 		return getByte() == t.getByte();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return GenericByteType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Byte.hashCode( getByte() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericIntType.java
@@ -178,26 +178,6 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Integer#hashCode().
-		return getInt();
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final int a = getInt();
-		final int b = c.getInt();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public void set( final T c )
 	{
 		setInt( c.getInt() );
@@ -278,8 +258,30 @@ public abstract class GenericIntType< T extends GenericIntType< T > > extends Ab
 	}
 
 	@Override
+	public int compareTo( final T other )
+	{
+		return Integer.compare( getInt(), other.getInt() );
+	}
+
+	@Override
 	public boolean valueEquals( final T t )
 	{
 		return getInt() == t.getInt();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return GenericIntType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Integer.hashCode( getInt() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
@@ -173,7 +173,7 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	public int hashCode()
 	{
 		// NB: Use the same hash code as java.lang.Long#hashCode().
-		return ( ( Long ) getLong() ).hashCode();
+		return Long.hashCode( getLong() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericLongType.java
@@ -170,26 +170,6 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		return Long.hashCode( getLong() );
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final long a = getLong();
-		final long b = c.getLong();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public void set( final T c )
 	{
 		setLong( c.getLong() );
@@ -270,8 +250,30 @@ public abstract class GenericLongType< T extends GenericLongType< T > > extends 
 	}
 
 	@Override
-	public boolean valueEquals( final T t )
+	public int compareTo( final T other )
 	{
-		return getLong() == t.getLong();
+		return Long.compare( getLong(), other.getLong() );
+	}
+
+	@Override
+	public boolean valueEquals( final T other )
+	{
+		return getLong() == other.getLong();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return GenericLongType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Long.hashCode( getLong() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/GenericShortType.java
@@ -182,26 +182,6 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Short#hashCode().
-		return getShort();
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final short a = getShort();
-		final short b = c.getShort();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public void set( final T c )
 	{
 		setShort( c.getShort() );
@@ -221,8 +201,7 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 
 	@Override
 	public void inc()
-	{
-		short a = getShort();
+	{ short a = getShort();
 		setShort( ++a );
 	}
 
@@ -282,8 +261,31 @@ public abstract class GenericShortType< T extends GenericShortType< T > >
 	}
 
 	@Override
+	public int compareTo( final T other )
+	{
+		// NB: Use Integer.compare because Short.compare returns values different from -1, 0, 1.
+		return Integer.compare( getShort(), other.getShort() );
+	}
+
+	@Override
 	public boolean valueEquals( final T t )
 	{
 		return getShort() == t.getShort();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return GenericShortType.this.valueEquals( t );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Short.hashCode( getShort() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/LongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/LongType.java
@@ -89,7 +89,7 @@ public class LongType extends GenericLongType< LongType >
 
 	public long get()
 	{
-		return dataAccess.getValue( i );
+		return getLong();
 	}
 
 	public void set( final long f )
@@ -143,27 +143,6 @@ public class LongType extends GenericLongType< LongType >
 	public double getMinValue()
 	{
 		return Long.MIN_VALUE;
-	}
-
-	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		final long value = get();
-		return ( int ) ( value ^ ( value >>> 32 ) );
-	}
-
-	@Override
-	public int compareTo( final LongType c )
-	{
-		final long a = get();
-		final long b = c.get();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/integer/ShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/ShortType.java
@@ -39,6 +39,7 @@ import java.math.BigInteger;
 import net.imglib2.img.NativeImg;
 import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.util.Util;
 
 /**
  * TODO

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -451,4 +451,12 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 		return ( dataAccess.getValue( k ) == t.dataAccess.getValue( kt ) ) &&
 				( dataAccess.getValue( k + 1 ) == t.dataAccess.getValue( kt + 1 ) );
 	}
+
+	@Override
+	public int hashCode()
+	{
+		final int k = i * 2;
+		return 31 * Long.hashCode( dataAccess.getValue( k + 1 ) )
+				+ Long.hashCode( dataAccess.getValue( k ) );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/Unsigned128BitType.java
@@ -45,6 +45,7 @@ import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Fraction;
+import net.imglib2.util.Util;
 
 /**
  * A {@link Type} with a bit depth of 128. Each value is stored in two adjacent
@@ -453,10 +454,17 @@ public class Unsigned128BitType extends AbstractIntegerType< Unsigned128BitType 
 	}
 
 	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
 	public int hashCode()
 	{
 		final int k = i * 2;
-		return 31 * Long.hashCode( dataAccess.getValue( k + 1 ) )
-				+ Long.hashCode( dataAccess.getValue( k ) );
+		final int hash1 = Long.hashCode( dataAccess.getValue( k + 1 ) );
+		final int hash2 = Long.hashCode( dataAccess.getValue( k ) );
+		return Util.combineHash( hash1, hash2 );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedByteType.java
@@ -205,27 +205,6 @@ public class UnsignedByteType extends GenericByteType< UnsignedByteType >
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Integer#hashCode().
-		return get();
-	}
-
-	@Override
-	public int compareTo( final UnsignedByteType c )
-	{
-		final int a = get();
-		final int b = c.get();
-
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public UnsignedByteType createVariable()
 	{
 		return new UnsignedByteType( 0 );
@@ -241,5 +220,29 @@ public class UnsignedByteType extends GenericByteType< UnsignedByteType >
 	public String toString()
 	{
 		return "" + get();
+	}
+
+	@Override
+	public int compareTo( final UnsignedByteType other )
+	{
+		return Integer.compare( get(), other.get() );
+	}
+
+	@Override
+	public boolean valueEquals( UnsignedByteType type )
+	{
+		return getByte() == type.getByte();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Integer.hashCode( get() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedIntType.java
@@ -234,28 +234,6 @@ public class UnsignedIntType extends GenericIntType< UnsignedIntType >
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		final long value = get();
-		return ( int ) ( value ^ ( value >>> 32 ) );
-	}
-
-	@Override
-	public int compareTo( final UnsignedIntType c )
-	{
-		final long a = get();
-		final long b = c.get();
-
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public UnsignedIntType createVariable()
 	{
 		return new UnsignedIntType( 0 );
@@ -265,5 +243,29 @@ public class UnsignedIntType extends GenericIntType< UnsignedIntType >
 	public UnsignedIntType copy()
 	{
 		return new UnsignedIntType( get() );
+	}
+
+	@Override
+	public int compareTo( final UnsignedIntType other )
+	{
+		return Long.compare( get(), other.get() );
+	}
+
+	@Override
+	public boolean valueEquals( UnsignedIntType other )
+	{
+		return getInt() == other.getInt();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Integer.hashCode( getInt() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedLongType.java
@@ -181,14 +181,6 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Long#hashCode().
-		final long value = get();
-		return ( int ) ( value ^ ( value >>> 32 ) );
-	}
-
-	@Override
 	public void setOne()
 	{
 		set( 1 );
@@ -303,12 +295,6 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 		return 0;
 	}
 
-	@Override
-	public int compareTo( final UnsignedLongType c )
-	{
-		return compare( get(), c.get() );
-	}
-
 	/**
 	 *
 	 * @param a
@@ -356,4 +342,27 @@ public class UnsignedLongType extends GenericLongType< UnsignedLongType >
 		return l >= 0 ? l : (MAX_VALUE_PLUS_ONE + l);
 	}
 
+	@Override
+	public int compareTo( final UnsignedLongType other )
+	{
+		return compare( get(), other.get() );
+	}
+
+	@Override
+	public boolean valueEquals( UnsignedLongType other )
+	{
+		return getLong() == other.getLong();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Long.hashCode( getLong() );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedShortType.java
@@ -214,27 +214,6 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Integer#hashCode().
-		return get();
-	}
-
-	@Override
-	public int compareTo( final UnsignedShortType c )
-	{
-		final int a = get();
-		final int b = c.get();
-
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public UnsignedShortType createVariable()
 	{
 		return new UnsignedShortType( 0 );
@@ -250,5 +229,29 @@ public class UnsignedShortType extends GenericShortType< UnsignedShortType >
 	public String toString()
 	{
 		return "" + get();
+	}
+
+	@Override
+	public int compareTo( final UnsignedShortType other )
+	{
+		return Integer.compare( get(), other.get() );
+	}
+
+	@Override
+	public boolean valueEquals( UnsignedShortType other )
+	{
+		return getShort() == other.getShort();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Integer.hashCode( get() );
 	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
@@ -359,4 +359,10 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 	{
 		return getBits() == t.getBits();
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return Long.hashCode( getBits() );
+	}
 }

--- a/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
+++ b/src/main/java/net/imglib2/type/numeric/integer/UnsignedVariableBitLengthType.java
@@ -131,13 +131,6 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 		setBits( UnsignedLongType.divide( getBits(), t.getBits() ) );
 	}
 
-	/** @see UnsignedLongType#compare(long, long) */
-	@Override
-	public int compareTo( final UnsignedVariableBitLengthType t )
-	{
-		return UnsignedLongType.compare( getBits(), t.getBits() );
-	}
-
 	@Override
 	public void mul( final float c )
 	{
@@ -347,6 +340,13 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 	public void complexConjugate()
 	{}
 
+	/** @see UnsignedLongType#compare(long, long) */
+	@Override
+	public int compareTo( final UnsignedVariableBitLengthType t )
+	{
+		return UnsignedLongType.compare( getBits(), t.getBits() );
+	}
+
 	/**
 	 * Default test at long precision. Please override for types longer than
 	 * 64bit.
@@ -358,6 +358,12 @@ public class UnsignedVariableBitLengthType extends AbstractBit64Type< UnsignedVa
 	public boolean valueEquals( final UnsignedVariableBitLengthType t )
 	{
 		return getBits() == t.getBits();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -36,6 +36,7 @@ package net.imglib2.type.numeric.real;
 
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.complex.AbstractComplexType;
+import net.imglib2.util.Casts;
 
 /**
  * TODO
@@ -144,11 +145,7 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if ( !getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings("unchecked")
-		final T t = (T) obj;
-		return AbstractRealType.this.valueEquals( t );
+		return getClass().isInstance( obj ) && AbstractRealType.this.valueEquals( Casts.unchecked( obj ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/AbstractRealType.java
@@ -130,34 +130,31 @@ public abstract class AbstractRealType< T extends AbstractRealType< T >> extends
 	}
 
 	@Override
-	public boolean equals( final Object o )
+	public int compareTo( final T other )
 	{
-		if ( !getClass().isInstance(o) )
+		return Double.compare( getRealDouble(), other.getRealDouble() );
+	}
+
+	@Override
+	public boolean valueEquals( T other )
+	{
+		return getRealDouble() == other.getRealDouble();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		if ( !getClass().isInstance( obj ) )
 			return false;
 		@SuppressWarnings("unchecked")
-		final T t = (T) o;
-		return compareTo(t) == 0;
+		final T t = (T) obj;
+		return AbstractRealType.this.valueEquals( t );
 	}
 
 	@Override
 	public int hashCode()
 	{
-		// NB: Use the same hash code as java.lang.Double#hashCode().
-		final long bits = Double.doubleToLongBits(getRealDouble());
-		return (int) (bits ^ (bits >>> 32));
-	}
-
-	@Override
-	public int compareTo( final T c )
-	{
-		final double a = getRealDouble();
-		final double b = c.getRealDouble();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
+		return Double.hashCode( getRealDouble() );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/DoubleType.java
@@ -214,10 +214,4 @@ public class DoubleType extends AbstractRealType< DoubleType > implements Native
 	{
 		return 64;
 	}
-
-	@Override
-	public boolean valueEquals( final DoubleType t )
-	{
-		return get() == t.get();
-	}
 }

--- a/src/main/java/net/imglib2/type/numeric/real/FloatType.java
+++ b/src/main/java/net/imglib2/type/numeric/real/FloatType.java
@@ -40,6 +40,7 @@ import net.imglib2.img.basictypeaccess.array.FloatArray;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.util.Fraction;
+import net.imglib2.util.Util;
 
 /**
  * TODO
@@ -192,26 +193,6 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	}
 
 	@Override
-	public int hashCode()
-	{
-		// NB: Use the same hash code as java.lang.Float#hashCode().
-		return Float.floatToIntBits( get() );
-	}
-
-	@Override
-	public int compareTo( final FloatType c )
-	{
-		final float a = get();
-		final float b = c.get();
-		if ( a > b )
-			return 1;
-		else if ( a < b )
-			return -1;
-		else
-			return 0;
-	}
-
-	@Override
 	public void set( final FloatType c )
 	{
 		set( c.get() );
@@ -304,8 +285,26 @@ public class FloatType extends AbstractRealType< FloatType > implements NativeTy
 	}
 
 	@Override
-	public boolean valueEquals( final FloatType t )
+	public int compareTo( final FloatType other )
 	{
-		return get() == t.get();
+		return Float.compare( get(), other.get() );
+	}
+
+	@Override
+	public boolean valueEquals( final FloatType other )
+	{
+		return get() == other.get();
+	}
+
+	@Override
+	public boolean equals( final Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Float.hashCode( get() );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -36,6 +36,7 @@ package net.imglib2.type.volatiles;
 
 import net.imglib2.Volatile;
 import net.imglib2.type.numeric.NumericType;
+import net.imglib2.util.Util;
 
 /**
  * Abstract base class for {@link VolatileNumericType}s that wrap a
@@ -125,5 +126,11 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	public boolean valueEquals( T other )
 	{
 		return ( isValid() && other.isValid() ) && t.valueEquals( other.t );
+	}
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -36,6 +36,7 @@ package net.imglib2.type.volatiles;
 
 import net.imglib2.Volatile;
 import net.imglib2.type.numeric.NumericType;
+import net.imglib2.util.Casts;
 import net.imglib2.util.Util;
 
 /**
@@ -131,11 +132,7 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if( ! getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings( "unchecked" )
-		T t = ( T ) obj;
-		return AbstractVolatileNumericType.this.valueEquals( t );
+		return getClass().isInstance( obj ) && AbstractVolatileNumericType.this.valueEquals( Casts.unchecked( t ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -38,6 +38,8 @@ import net.imglib2.Volatile;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Util;
 
+import java.util.Objects;
+
 /**
  * Abstract base class for {@link VolatileNumericType}s that wrap a
  * {@link NumericType} that is either VALID or INVALID.
@@ -132,5 +134,11 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	public boolean equals( Object obj )
 	{
 		return Util.valueEqualsObject( this, obj );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return isValid() ? t.hashCode() : super.hashCode();
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileNumericType.java
@@ -38,8 +38,6 @@ import net.imglib2.Volatile;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.util.Util;
 
-import java.util.Objects;
-
 /**
  * Abstract base class for {@link VolatileNumericType}s that wrap a
  * {@link NumericType} that is either VALID or INVALID.
@@ -127,18 +125,22 @@ abstract public class AbstractVolatileNumericType< N extends NumericType< N >, T
 	@Override
 	public boolean valueEquals( T other )
 	{
-		return ( isValid() && other.isValid() ) && t.valueEquals( other.t );
+		return (isValid() == other.isValid()) && t.valueEquals( other.t );
 	}
 
 	@Override
-	public boolean equals( Object obj )
+	public boolean equals( final Object obj )
 	{
-		return Util.valueEqualsObject( this, obj );
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return AbstractVolatileNumericType.this.valueEquals( t );
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return isValid() ? t.hashCode() : super.hashCode();
+		return Util.combineHash( Boolean.hashCode( isValid() ), t.hashCode() );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -35,6 +35,7 @@ package net.imglib2.type.volatiles;
 
 import net.imglib2.Volatile;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
 
 /**
  * Abstract base class for {@link VolatileRealType}s that wrap {@link RealType}.
@@ -251,5 +252,11 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	public boolean valueEquals( T other )
 	{
 		return ( isValid() && other.isValid() ) && t.valueEquals( other.t );
+	}
+
+	@Override
+	public boolean equals( Object obj )
+	{
+		return Util.valueEqualsObject( this, obj );
 	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -35,6 +35,7 @@ package net.imglib2.type.volatiles;
 
 import net.imglib2.Volatile;
 import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Casts;
 import net.imglib2.util.Util;
 
 /**
@@ -257,11 +258,7 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	@Override
 	public boolean equals( final Object obj )
 	{
-		if( ! getClass().isInstance( obj ) )
-			return false;
-		@SuppressWarnings( "unchecked" )
-		T t = ( T ) obj;
-		return AbstractVolatileRealType.this.valueEquals( t );
+		return getClass().isInstance( obj ) && AbstractVolatileRealType.this.valueEquals( Casts.unchecked( t ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -249,13 +249,13 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
-	public boolean valueEquals( T other )
+	public boolean valueEquals( final T other )
 	{
-		return ( isValid() && other.isValid() ) && t.valueEquals( other.t );
+		return ( isValid() == other.isValid() ) && t.valueEquals( other.t );
 	}
 
 	@Override
-	public boolean equals( Object obj )
+	public boolean equals( final Object obj )
 	{
 		return Util.valueEqualsObject( this, obj );
 	}

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -259,4 +259,10 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	{
 		return Util.valueEqualsObject( this, obj );
 	}
+
+	@Override
+	public int hashCode()
+	{
+		return isValid() ? t.hashCode() : super.hashCode();
+	}
 }

--- a/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
+++ b/src/main/java/net/imglib2/type/volatiles/AbstractVolatileRealType.java
@@ -148,12 +148,6 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
-	public int compareTo( final T o )
-	{
-		return t.compareTo( o.t );
-	}
-
-	@Override
 	public void inc()
 	{
 		t.inc();
@@ -249,20 +243,30 @@ public abstract class AbstractVolatileRealType< R extends RealType< R >, T exten
 	}
 
 	@Override
-	public boolean valueEquals( final T other )
+	public int compareTo( final T o )
 	{
-		return ( isValid() == other.isValid() ) && t.valueEquals( other.t );
+		return t.compareTo( o.t );
+	}
+
+	@Override
+	public boolean valueEquals( T other )
+	{
+		return (isValid() == other.isValid()) && t.valueEquals( other.t );
 	}
 
 	@Override
 	public boolean equals( final Object obj )
 	{
-		return Util.valueEqualsObject( this, obj );
+		if( ! getClass().isInstance( obj ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		T t = ( T ) obj;
+		return AbstractVolatileRealType.this.valueEquals( t );
 	}
 
 	@Override
 	public int hashCode()
 	{
-		return isValid() ? t.hashCode() : super.hashCode();
+		return Util.combineHash( Boolean.hashCode( isValid() ), t.hashCode() );
 	}
 }

--- a/src/main/java/net/imglib2/util/Casts.java
+++ b/src/main/java/net/imglib2/util/Casts.java
@@ -1,0 +1,15 @@
+package net.imglib2.util;
+
+public final class Casts
+{
+
+	private Casts() {
+		// prevent from instantiation
+	}
+
+	public static <T> T unchecked( final Object value ) {
+		@SuppressWarnings( "unchecked" )
+		T t = (T) value;
+		return t;
+	}
+}

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -1039,9 +1039,9 @@ public class Util
 	 *
 	 * @see net.imglib2.type.AbstractNativeType#equals(Object)
 	 */
-	public static <T extends ValueEquals<S>, S extends T> boolean valueEqualsObject( T a, Object b )
+	public static < T extends ValueEquals< S >, S extends T > boolean valueEqualsObject( T a, Object b )
 	{
-		if( ! a.getClass().isInstance( b ) )
+		if ( !a.getClass().isInstance( b ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
 		S s = ( S ) b;

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -1032,4 +1032,19 @@ public class Util
 	{
 		return asDoubleArray( ( RandomAccessibleInterval< ? extends RealType< ? > > ) image );
 	}
+
+	/**
+	 * This method should be used in implementations of {@link ValueEquals},
+	 * to override {@link Object#equals(Object)}.
+	 *
+	 * @see net.imglib2.type.AbstractNativeType#equals(Object)
+	 */
+	public static <T extends ValueEquals<S>, S extends T> boolean valueEqualsObject( T a, Object b )
+	{
+		if( ! a.getClass().isInstance( b ) )
+			return false;
+		@SuppressWarnings( "unchecked" )
+		S s = ( S ) b;
+		return a.valueEquals( s );
+	}
 }

--- a/src/main/java/net/imglib2/util/Util.java
+++ b/src/main/java/net/imglib2/util/Util.java
@@ -1039,12 +1039,17 @@ public class Util
 	 *
 	 * @see net.imglib2.type.AbstractNativeType#equals(Object)
 	 */
-	public static < T extends ValueEquals< S >, S extends T > boolean valueEqualsObject( T a, Object b )
+	public static <T extends ValueEquals<T>> boolean valueEqualsObject( T a, Object b )
 	{
 		if ( !a.getClass().isInstance( b ) )
 			return false;
 		@SuppressWarnings( "unchecked" )
-		S s = ( S ) b;
-		return a.valueEquals( s );
+		T t = ( T ) b;
+		return a.valueEquals( t );
+	}
+
+	public static int combineHash( int hash1, int hash2 )
+	{
+		return 31 * hash1 + hash2;
 	}
 }

--- a/src/test/java/net/imglib2/ComparingDoubles.java
+++ b/src/test/java/net/imglib2/ComparingDoubles.java
@@ -1,0 +1,5 @@
+package net.imglib2;
+
+public class ComparingDoubles
+{
+}

--- a/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
@@ -79,6 +79,7 @@ import java.util.stream.Collectors;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
@@ -253,6 +254,24 @@ public class NumericTypeTest< T extends NumericType< T > >
 		T value = newNumber( 6 );
 		value.div( newNumber( 2 ) );
 		assertEquals( newNumber( 3 ), value );
+	}
+
+	@Test
+	public void testHashCodeEquals()
+	{
+		int hashA = newOne().hashCode();
+		int hashB = newOne().hashCode();
+		assertEquals(hashA, hashB);
+	}
+
+	@Test
+	public void testHashCodeChanges()
+	{
+		T variable = newZero();
+		int hashZero = variable.hashCode();
+		variable.set( newOne() );
+		int hashOne = variable.hashCode();
+		assertNotEquals(hashZero, hashOne);
 	}
 
 	// -- Helper methods --

--- a/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
@@ -1,0 +1,290 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.type.numeric;
+
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.numeric.complex.ComplexDoubleType;
+import net.imglib2.type.numeric.complex.ComplexFloatType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.integer.UnsignedVariableBitLengthType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.type.volatiles.VolatileARGBType;
+import net.imglib2.type.volatiles.VolatileByteType;
+import net.imglib2.type.volatiles.VolatileDoubleType;
+import net.imglib2.type.volatiles.VolatileFloatType;
+import net.imglib2.type.volatiles.VolatileIntType;
+import net.imglib2.type.volatiles.VolatileLongType;
+import net.imglib2.type.volatiles.VolatileNumericType;
+import net.imglib2.type.volatiles.VolatileRealType;
+import net.imglib2.type.volatiles.VolatileShortType;
+import net.imglib2.type.volatiles.VolatileUnsignedByteType;
+import net.imglib2.type.volatiles.VolatileUnsignedIntType;
+import net.imglib2.type.volatiles.VolatileUnsignedLongType;
+import net.imglib2.type.volatiles.VolatileUnsignedShortType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+
+/**
+ * Test basic functionality of every NumericType implementation.
+ * <p>
+ * It's a parameterized test, see <a href="https://github.com/junit-team/junit4/wiki/parameterized-tests">Junit4 Parameterized Test</a>.
+ * The test is executed for every type in the list {@link NumericTypeTest#numericTypes}.
+ *
+ * @param <T>
+ */
+@RunWith( Parameterized.class )
+public class NumericTypeTest< T extends NumericType< T > >
+{
+	private static final List< NumericType< ? > > numericTypes = Arrays.asList(
+			new ARGBDoubleType(),
+			new ARGBType(),
+			new BitType(),
+			new BoolType(),
+			new ByteType(),
+			new ComplexDoubleType(),
+			new ComplexFloatType(),
+			new DoubleType(),
+			new FloatType(),
+			new IntType(),
+			new LongType(),
+			new ShortType(),
+			new UnsignedByteType(),
+			new UnsignedIntType(),
+			new UnsignedLongType(),
+			new UnsignedShortType(),
+			new Unsigned128BitType(),
+			new Unsigned2BitType(),
+			new Unsigned4BitType(),
+			new Unsigned12BitType(),
+			new UnsignedVariableBitLengthType( 7 ),
+			new VolatileARGBType(),
+			new VolatileByteType(),
+			new VolatileDoubleType(),
+			new VolatileFloatType(),
+			new VolatileIntType(),
+			new VolatileLongType(),
+			new VolatileShortType(),
+			new VolatileUnsignedByteType(),
+			new VolatileUnsignedIntType(),
+			new VolatileUnsignedLongType(),
+			new VolatileUnsignedShortType(),
+			new VolatileNumericType<>( new DoubleType() ),
+			new VolatileRealType<>( new DoubleType() )
+	);
+
+	private final T type;
+
+	// NB: The class is parameterized with pairs of (className, numeric type)
+	// className is there for nicer error messages when a test fails.
+	@Parameterized.Parameters( name = "{0}" )
+	public static Collection< Object > data()
+	{
+		return numericTypes.stream().map(
+				type -> new Object[] { type.getClass().getSimpleName(), type }
+		).collect( Collectors.toList() );
+	}
+
+	public NumericTypeTest( String className, T type )
+	{
+		this.type = type;
+	}
+
+	@Test
+	public void testValueEquals()
+	{
+		boolean result = newOne().valueEquals( newOne() );
+		assumeTrue( result );
+	}
+
+	@Test
+	public void testNotValueEquals()
+	{
+		boolean result = newZero().valueEquals( newOne() );
+		assumeFalse( result );
+	}
+
+	@Test
+	public void testEquals()
+	{
+		boolean result = newOne().equals( newOne() );
+		assertTrue( result );
+	}
+
+	@Test
+	public void testNotEqual()
+	{
+		boolean result = newOne().equals( newZero() );
+		assertFalse( result );
+	}
+
+	@Test
+	public void testSet()
+	{
+		T a = newZero();
+		T b = newOne();
+		a.set( b );
+		assertEquals( b, a );
+	}
+
+	@Test
+	public void testOneMinusOne()
+	{
+		T value = newOne();
+		value.sub( newOne() );
+		assertEquals( newZero(), value );
+	}
+
+	@Test
+	public void testAdd()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+
+		T value = newNumber( 3 );
+		value.add( newNumber( 2 ) );
+		assertEquals( newNumber( 5 ), value );
+	}
+
+	@Test
+	public void testSub()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+
+		T value = newNumber( 5 );
+		value.sub( newNumber( 3 ) );
+		assertEquals( newNumber( 2 ), value );
+	}
+
+	@Test
+	public void testMulNumerivType()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+		T value = newNumber( 3 );
+		value.mul( newNumber( 2 ) );
+		assertEquals( newNumber( 6 ), value );
+	}
+
+	@Test
+	public void testMulDouble()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+		T value = newNumber( 3 );
+		value.mul( 2.0 );
+		assertEquals( newNumber( 6 ), value );
+	}
+
+	@Test
+	public void testMulFloat()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+
+		T value = newNumber( 3 );
+		value.mul( 2.0f );
+		assertEquals( newNumber( 6 ), value );
+	}
+
+	@Test
+	public void testDiv()
+	{
+		if ( isMaxValueLessThanSix() )
+			return;
+		T value = newNumber( 6 );
+		value.div( newNumber( 2 ) );
+		assertEquals( newNumber( 3 ), value );
+	}
+
+	// -- Helper methods --
+
+	private T newZero()
+	{
+		T zero = type.createVariable();
+		zero.setZero();
+		return zero;
+	}
+
+	private T newOne()
+	{
+		T one = type.createVariable();
+		one.setOne();
+		return one;
+	}
+
+	private boolean isMaxValueLessThanSix()
+	{
+		return type instanceof BooleanType
+				|| type instanceof Unsigned2BitType;
+	}
+
+	private T newNumber( int value )
+	{
+		if ( value < 0 )
+			throw new AssertionError();
+		T result = newZero();
+		T one = newOne();
+		for ( int i = 0; i < value; i++ )
+			result.add( one );
+		return result;
+	}
+}

--- a/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/NumericTypeTest.java
@@ -74,6 +74,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import static junit.framework.TestCase.assertFalse;
@@ -272,6 +273,23 @@ public class NumericTypeTest< T extends NumericType< T > >
 		variable.set( newOne() );
 		int hashOne = variable.hashCode();
 		assertNotEquals(hashZero, hashOne);
+	}
+
+	@Test
+	public void testCompareTo() {
+		final T t = newZero();
+		if( ( t instanceof Comparable ) && !( t instanceof BooleanType ) )
+			testCompareTo( value -> (Comparable) newNumber( value ) );
+	}
+
+	private static void testCompareTo( IntFunction< Comparable > newNumber )
+	{
+		Comparable zero = newNumber.apply( 0 );
+		Comparable two = newNumber.apply( 2 );
+		Comparable anatherTwo = newNumber.apply( 2 );
+		assertEquals( -1, zero.compareTo( two ) );
+		assertEquals( 1, two.compareTo( zero ) );
+		assertEquals( 0, two.compareTo( anatherTwo ) );
 	}
 
 	// -- Helper methods --

--- a/src/test/java/net/imglib2/type/numeric/complex/ComplexDoubleTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/complex/ComplexDoubleTypeTest.java
@@ -76,13 +76,4 @@ public class ComplexDoubleTypeTest
 		assertTrue( i4.equals( b ) );
 	}
 
-
-	/** Tests {@link ComplexDoubleType#hashCode()}. */
-	@Test
-	public void testHashCode()
-	{
-		final ComplexDoubleType b = new ComplexDoubleType( 1.234, 5.678 );
-		assertEquals( 379318760, b.hashCode() );
-	}
-
 }

--- a/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
@@ -82,7 +82,7 @@ public class ComplexFloatTypeTest
 	public void testHashCode()
 	{
 		final ComplexFloatType b = new ComplexFloatType( 1.234f, 5.678f );
-		assertEquals( 535103539, b.hashCode() );
+		assertEquals( 2133344667, b.hashCode() );
 	}
 
 }

--- a/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
+++ b/src/test/java/net/imglib2/type/numeric/complex/ComplexFloatTypeTest.java
@@ -75,14 +75,4 @@ public class ComplexFloatTypeTest
 		assertTrue( b.equals( i4 ) );
 		assertTrue( i4.equals( b ) );
 	}
-
-
-	/** Tests {@link ComplexFloatType#hashCode()}. */
-	@Test
-	public void testHashCode()
-	{
-		final ComplexFloatType b = new ComplexFloatType( 1.234f, 5.678f );
-		assertEquals( 2133344667, b.hashCode() );
-	}
-
 }

--- a/src/test/java/net/imglib2/util/UtilTest.java
+++ b/src/test/java/net/imglib2/util/UtilTest.java
@@ -48,13 +48,14 @@ import net.imglib2.type.logic.BoolType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.operators.ValueEquals;
 import org.junit.Test;
 
 import java.util.function.BiPredicate;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class UtilTest
@@ -186,5 +187,44 @@ public class UtilTest
 		Img< DoubleType > img = ArrayImgs.doubles( expected, 2, 2 );
 		double[] result = Util.asDoubleArray( img );
 		assertArrayEquals( expected, result, 0.0 );
+	}
+
+	/**
+	 * Tests {@link Util#valueEqualsObject(ValueEquals, Object)}.
+	 * <p>
+	 * Class {@link Simple} demonstrates how the method is supposed to be used.
+	 */
+	@Test
+	public void testValueEqualsObject()
+	{
+		Simple four = new Simple( 4 );
+		assertTrue( four.equals( four ) );
+		assertTrue( four.equals( new Simple( 4 ) ) );
+		assertFalse( four.equals( new Simple( 5 ) ) );
+		assertFalse( four.equals( new Object() ) );
+		assertFalse( four.equals( null ) );
+	}
+
+	private static class Simple implements ValueEquals< Simple >
+	{
+
+		private final int value;
+
+		private Simple( int value )
+		{
+			this.value = value;
+		}
+
+		@Override
+		public boolean valueEquals( Simple simple )
+		{
+			return this.value == simple.value;
+		}
+
+		@Override
+		public boolean equals( Object obj )
+		{
+			return Util.valueEqualsObject( this, obj );
+		}
 	}
 }


### PR DESCRIPTION
Java has a very half backed implementation for generics. It is therefor
often necessary to perform unchecked casts.
The cumbersome syntax in Java forces the developer to either:
 * ignore the warnings, or
 * clutter the code with @SuppressWarnings annotations.

This commit suggest a third way, it introduces a nice and small method for unchecked casts:
```java
public static <T> T unchecked( final Object value ) {
	@SuppressWarnings( "unchecked" )
	T t = (T) value;
	return t;
}
```
And shows how it can be used to increase code readability.